### PR TITLE
Add the ability to set environment variables in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,67 @@ On Debian, move the `termfilechooser.portal` file:
 By default, the contents of the `contrib` folder are placed in `/usr/local/share/xdg-desktop-portal-termfilechooser/`.
 Copy the `config` to `~/.config/xdg-desktop-portal-termfilechooser` and edit it to set your preferred wrapper and default directory.
 
-To set your terminal emulator, you can use the `TERMCMD` environment variable instead of editing the wrapper file directly. This environment variable can also be set in the `cmd` key in the `config` if so desired (this is shown in the 2nd example below).
-Example:
+The main options for customizing how the filepicker is launched (in recommended order) are:
 
--   `$HOME/.profile`
--   `.bashrc`
+- Editing the `env` key in the `config`
+- Prepending your environment variables in the `cmd` key in the `config`
+- Exporting a global `TERMCMD` environment variable
+- Creating/Editing your own wrapper file
+
+#### Example:
+
+##### Editing `env`:
+
+```conf
+### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
+
+[filechooser]
+cmd=/usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+default_dir=$HOME/Downloads
+env=VARIABLE1=VALUE1
+    VARIABLE2=VALUE2
+```
+OR
+```conf
+### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
+
+[filechooser]
+cmd=/usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+default_dir=$HOME/Downloads
+env=VARIABLE1=VALUE1
+env=VARIABLE2=VALUE2
+```
+
+Environment variables that unset values are also allowed. (e.g. `env=VARIABLE=`)
+
+##### Prepending variables:
+
+```conf
+### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
+
+[filechooser]
+cmd=TERMCMD='wezterm start --always-new-process' /usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+default_dir=$HOME/Downloads
+```
+
+##### Exporting a global:
 
 ```sh
+### $HOME/.profile, .bashrc, or equivalent ###
+
 # use wezterm intead of kitty
 export TERMCMD="wezterm start --always-new-process"
 ```
 
--   `$HOME/.config/xdg-desktop-portal-termfilechooser/config`
+##### Copying wrapper:
+
+```cp /usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/custom-yazi-wrapper.sh```
 
 ```conf
+### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
+
 [filechooser]
-cmd=TERMCMD='wezterm start --always-new-process' /usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+cmd=$XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/custom-yazi-wrapper.sh
 default_dir=$HOME/Downloads
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ On Debian, move the `termfilechooser.portal` file:
 By default, the contents of the `contrib` folder are placed in `/usr/local/share/xdg-desktop-portal-termfilechooser/`.
 Copy the `config` to `~/.config/xdg-desktop-portal-termfilechooser` and edit it to set your preferred wrapper and default directory.
 
+Wrappers specified within the `cmd` key in the `config` are searched for in order of the following directories unless the full path is specified.
+
+- `$XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser`
+- `/usr/local/share/xdg-desktop-portal-termfilechooser`
+- `/usr/share/xdg-desktop-portal-termfilechooser`
+- Any other directory in your `$PATH`
+
 The main options for customizing how the filepicker is launched (in recommended order) are:
 
 - Editing the `env` key in the `config`
@@ -81,7 +88,7 @@ The main options for customizing how the filepicker is launched (in recommended 
 ### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
 
 [filechooser]
-cmd=/usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+cmd=yazi-wrapper.sh
 default_dir=$HOME/Downloads
 env=VARIABLE1=VALUE1
     VARIABLE2=VALUE2
@@ -91,7 +98,7 @@ OR
 ### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
 
 [filechooser]
-cmd=/usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+cmd=yazi-wrapper.sh
 default_dir=$HOME/Downloads
 env=VARIABLE1=VALUE1
 env=VARIABLE2=VALUE2
@@ -105,7 +112,7 @@ Environment variables that unset values are also allowed. (e.g. `env=VARIABLE=`)
 ### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
 
 [filechooser]
-cmd=TERMCMD='wezterm start --always-new-process' /usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+cmd=TERMCMD='wezterm start --always-new-process' yazi-wrapper.sh
 default_dir=$HOME/Downloads
 ```
 
@@ -120,13 +127,14 @@ export TERMCMD="wezterm start --always-new-process"
 
 ##### Copying wrapper:
 
-```cp /usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/custom-yazi-wrapper.sh```
+```cp /usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh```
 
 ```conf
 ### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
 
 [filechooser]
-cmd=$XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/custom-yazi-wrapper.sh
+# prioritizes `yazi-wrapper.sh` in `$XDG_CONFIG_HOME` dir over `/usr/local/share` dir
+cmd=yazi-wrapper.sh
 default_dir=$HOME/Downloads
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Environment variables that unset values are also allowed. (e.g. `env=VARIABLE=`)
 ### $XDG_CONFIG_HOME/xdg-desktop-portal-termfilechooser/config ###
 
 [filechooser]
-cmd=TERMCMD='wezterm start --always-new-process' yazi-wrapper.sh
+cmd=TERMCMD='foot' yazi-wrapper.sh
 default_dir=$HOME/Downloads
 ```
 
@@ -121,8 +121,8 @@ default_dir=$HOME/Downloads
 ```sh
 ### $HOME/.profile, .bashrc, or equivalent ###
 
-# use wezterm intead of kitty
-export TERMCMD="wezterm start --always-new-process"
+# use foot intead of kitty
+export TERMCMD="foot"
 ```
 
 ##### Copying wrapper:

--- a/contrib/config
+++ b/contrib/config
@@ -1,4 +1,4 @@
 [filechooser]
-cmd=/usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
+cmd=yazi-wrapper.sh
 default_dir=$HOME/Downloads
-;env=
+;env=TERMCMD=foot

--- a/contrib/config
+++ b/contrib/config
@@ -1,3 +1,4 @@
 [filechooser]
 cmd=/usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh
 default_dir=$HOME/Downloads
+;env=

--- a/contrib/config
+++ b/contrib/config
@@ -1,4 +1,5 @@
 [filechooser]
 cmd=yazi-wrapper.sh
 default_dir=$HOME/Downloads
-;env=TERMCMD=foot
+; Uncomment and edit the line below to change the terminal emulator command
+; env=TERMCMD=foot

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,2 +1,0 @@
-[filechooser]
-cmd=/usr/share/xdg-desktop-portal-termfilechooser/ranger-wrapper.sh

--- a/include/config.h
+++ b/include/config.h
@@ -3,9 +3,21 @@
 
 #include "logger.h"
 
+struct env_var {
+    char *name;
+    char *value;
+};
+
+struct environment {
+    int num_vars;
+    int capacity;
+    struct env_var *vars;
+};
+
 struct config_filechooser {
     char *cmd;
     char *default_dir;
+    struct environment *env;
 };
 
 struct xdpw_config {

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -14,6 +14,11 @@
 void print_config(enum LOGLEVEL loglevel, struct xdpw_config *config) {
     logprint(loglevel, "config: cmd:  %s", config->filechooser_conf.cmd);
     logprint(loglevel, "config: default_dir:  %s", config->filechooser_conf.default_dir);
+    for (int i = 0; i < config->filechooser_conf.env->num_vars; i++) {
+        logprint(loglevel, "config: env:  %s=%s",
+                 (config->filechooser_conf.env->vars + i)->name,
+                 (config->filechooser_conf.env->vars + i)->value);
+    }
 }
 
 // NOTE: calling finish_config won't prepare the config to be read again from config file
@@ -22,6 +27,12 @@ void finish_config(struct xdpw_config *config) {
     logprint(DEBUG, "config: destroying config");
     free(config->filechooser_conf.cmd);
     free(config->filechooser_conf.default_dir);
+    for (int i = 0; i < config->filechooser_conf.env->num_vars; i++) {
+        free((config->filechooser_conf.env->vars + i)->name);
+        free((config->filechooser_conf.env->vars + i)->value);
+    }
+    free(config->filechooser_conf.env->vars);
+    free(config->filechooser_conf.env);
 }
 
 static void parse_string(char **dest, const char* value) {
@@ -33,11 +44,48 @@ static void parse_string(char **dest, const char* value) {
     *dest = strdup(value);
 }
 
+static void parse_env(struct environment* env, const char* envstr) {
+    if (envstr == NULL || *envstr == '\0') {
+        logprint(TRACE, "config: skipping empty value in config file");
+        return;
+    }
+
+    char *sep = strchr(envstr, '=');
+    char *name = NULL;
+    char *value = NULL;
+
+    if (sep == NULL || sep == envstr) {
+        logprint(TRACE, "config: skipping corrupt env in config file");
+        return;
+    }
+    else {
+        name = strtok((char*)envstr, "=");
+        value = strtok(NULL, "\n");
+        if (value == NULL)
+            value = "";
+    }
+
+    // dynamically allocate more vars
+    if (env->num_vars == env->capacity){
+        env->capacity += 5;
+        env->vars = realloc(env->vars, sizeof(struct env_var) * env->capacity);
+    }
+
+    // create env_var and add to env
+    struct env_var *var = (env->vars + env->num_vars);
+    var->name = strdup(name);
+    var->value = strdup(value);
+
+    env->num_vars++;
+}
+
 static int handle_ini_filechooser(struct config_filechooser *filechooser_conf, const char *key, const char *value) {
     if (strcmp(key, "cmd") == 0) {
         parse_string(&filechooser_conf->cmd, value);
     } else if (strcmp(key, "default_dir") == 0) {
         parse_string(&filechooser_conf->default_dir, value);
+    } else if (strcmp(key, "env") == 0) {
+        parse_env(filechooser_conf->env, value);
     } else {
         logprint(TRACE, "config: skipping invalid key in config file");
         return 0;
@@ -64,6 +112,12 @@ static void default_config(struct xdpw_config *config) {
     size = snprintf(NULL, 0, "%s", FILECHOOSER_DEFAULT_DIR) + 1;
     config->filechooser_conf.default_dir = malloc(size);
     snprintf(config->filechooser_conf.default_dir, size, "%s", FILECHOOSER_DEFAULT_DIR);
+
+    struct environment *env = malloc(sizeof(struct environment));
+    env->num_vars = 0;
+    env->capacity = 10;
+    env->vars = malloc(sizeof(struct env_var) * env->capacity);
+    config->filechooser_conf.env = env;
 }
 
 static bool file_exists(const char *path) {

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include <ini.h>
 
-#define FILECHOOSER_DEFAULT_CMD "/usr/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh"
+#define FILECHOOSER_DEFAULT_CMD "/usr/local/share/xdg-desktop-portal-termfilechooser/yazi-wrapper.sh"
 #define FILECHOOSER_DEFAULT_DIR "/tmp"
 
 void print_config(enum LOGLEVEL loglevel, struct xdpw_config *config) {

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -196,6 +196,28 @@ static char *get_config_path(void) {
     return NULL;
 }
 
+void init_wrapper_path(struct environment *env, char * const configfile) {
+    char *sys_path = getenv("PATH");
+    char *config = configfile;
+    char *substr = strrchr(config, '/');
+    size_t cutoff = (size_t)(substr - config);
+    char *config_path = strndup(config, cutoff);
+    const char *const wrapper_paths =
+        "/usr/local/share/xdg-desktop-portal-termfilechooser:/usr/share/xdg-desktop-portal-termfilechooser";
+
+    size_t path_size = 0;
+    char *path_env = NULL;
+
+    path_size = snprintf(NULL, 0, "PATH=%s:%s:%s", config_path, wrapper_paths, sys_path);
+    path_env = malloc(path_size);
+    snprintf(path_env, path_size, "PATH=%s:%s:%s", config_path, wrapper_paths, sys_path);
+
+    parse_env(env, path_env);
+
+    free(path_env);
+    free(config_path);
+}
+
 void init_config(char ** const configfile, struct xdpw_config *config) {
     if (*configfile == NULL) {
         *configfile = get_config_path();
@@ -209,4 +231,5 @@ void init_config(char ** const configfile, struct xdpw_config *config) {
     if (ini_parse(*configfile, handle_ini_config, config) < 0) {
         logprint(ERROR, "config: unable to load config file %s", *configfile);
     }
+    init_wrapper_path(config->filechooser_conf.env, *configfile);
 }

--- a/src/filechooser/filechooser.c
+++ b/src/filechooser/filechooser.c
@@ -38,6 +38,8 @@ static int exec_filechooser(void *data, bool writing, bool multiple,
   snprintf(cmd, str_size, "%s %d %d %d \'%s\' \'%s\'", cmd_script, multiple,
            directory, writing, path, PATH_PORTAL);
 
+  struct environment *env = state->config->filechooser_conf.env;
+
   // Check if the portal file exists and have read write permission
   if (access(PATH_PORTAL, F_OK) == 0) {
     if (access(PATH_PORTAL, R_OK | W_OK) != 0) {
@@ -49,6 +51,13 @@ static int exec_filechooser(void *data, bool writing, bool multiple,
     }
   }
   remove(PATH_PORTAL);
+  for (int i = 0, ret = 0; i < env->num_vars; i++) {
+    logprint(TRACE, "setting env: %s=%s", (env->vars + i)->name, (env->vars + i)->value);
+    ret = setenv((env->vars + i)->name, (env->vars + i)->value, 1);
+    if (ret) {
+      logprint(WARN, "could not set env %s: %d", (env->vars + i)->name, errno);
+    }
+  }
   logprint(TRACE, "executing command: %s", cmd);
   int ret = system(cmd);
   if (ret) {


### PR DESCRIPTION
The `env` key was added. Setting the same key or using multiple lines will add variables to be set when running the wrapper script later.

Addresses #2 