### PR TITLE
Fix PATH truncate

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -209,7 +209,7 @@ void init_wrapper_path(struct environment *env, char * const configfile) {
     size_t path_size = 0;
     char *path_env = NULL;
 
-    path_size = snprintf(NULL, 0, "PATH=%s:%s:%s", config_path, wrapper_paths, sys_path);
+    path_size = 1 + snprintf(NULL, 0, "PATH=%s:%s:%s", config_path, wrapper_paths, sys_path);
     path_env = malloc(path_size);
     snprintf(path_env, path_size, "PATH=%s:%s:%s", config_path, wrapper_paths, sys_path);
 


### PR DESCRIPTION
`snprintf` size argument counts the string terminator but the return value ignores it. This leads to the last character of $PATH to be deleted.