### PR TITLE
Fix open dialog if the option "current_folder" is set

### DIFF
--- a/src/filechooser/filechooser.c
+++ b/src/filechooser/filechooser.c
@@ -233,6 +233,11 @@ static int method_open_file(sd_bus_message *msg, void *data,
             if (inner_ret < 0) {
                 return inner_ret;
             }
+            inner_ret = sd_bus_message_exit_container(msg);
+            if (inner_ret < 0) {
+                return inner_ret;
+            }
+
             current_folder = (char *)p;
             logprint(DEBUG, "dbus: option current_folder: %s", current_folder);
         } else {


### PR DESCRIPTION
Termfilechooser was working correctly everywhere but in Firefox. However, the base version from boydaihungst was working fine. 
I narrowed it down to the current_folder option which only Firefox used (though not always, either). I guess the exit_container got lost at some point, but it's necessary.

Thanks for this project, I hope this fix is fine :)