### PR TITLE
meson.build: use native scdoc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,7 @@ install_subdir(
     strip_directory: true,
 )
 
-scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7')
+scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7', native: true)
 if scdoc.found()
     man_pages = ['xdg-desktop-portal-termfilechooser.5.scd']
     foreach src : man_pages


### PR DESCRIPTION
Since scdoc is executed on the builder to generate the man page, it should be a native build.