### PR TITLE
Make launcher scripts compatible with non FHS systems

### DIFF
--- a/contrib/fzf-wrapper.sh
+++ b/contrib/fzf-wrapper.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
 #
 # For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
 
 set -ex
-PATH="/usr/bin:/bin"
+PATH="${PATH:-'/usr/bin:/bin'}"
 
 multiple="$1"
 directory="$2"

--- a/contrib/lf-wrapper.sh
+++ b/contrib/lf-wrapper.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
 #
 # For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
 
 set -ex
-PATH="/usr/bin:/bin"
+PATH="${PATH:-'/usr/bin:/bin'}"
 
 multiple="$1"
 directory="$2"

--- a/contrib/nnn-wrapper.sh
+++ b/contrib/nnn-wrapper.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
 #
 # For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
 
 set -ex
-PATH="/usr/bin:/bin"
+PATH="${PATH:-'/usr/bin:/bin'}"
 
 multiple="$1"
 directory="$2"

--- a/contrib/ranger-wrapper.sh
+++ b/contrib/ranger-wrapper.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
 #
 # For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
 
 set -ex
-PATH="/usr/bin:/bin"
+PATH="${PATH:-'/usr/bin:/bin'}"
 
 multiple="$1"
 directory="$2"

--- a/contrib/vifm-wrapper.sh
+++ b/contrib/vifm-wrapper.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
 #
 # For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
 
 set -ex
-PATH="/usr/bin:/bin"
+PATH="${PATH:-'/usr/bin:/bin'}"
 
 multiple="$1"
 directory="$2"

--- a/contrib/yazi-wrapper.sh
+++ b/contrib/yazi-wrapper.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
 #
 # For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
 
 set -ex
-PATH="/usr/bin:/bin"
+PATH="${PATH:-'/usr/bin:/bin'}"
 
 multiple="$1"
 directory="$2"


### PR DESCRIPTION
Hi, thanks for this nice portal backend!

The launcher scripts do not work on non-FHS systems (ie systems where the binaries are not located in `/usr/bin`).
That is the case of NixOS, on which it isn't easy to use them without manual modification (see: https://discourse.nixos.org/t/how-to-install-xdg-desktop-portal-termfilechooser/62819/11).  

This PR fixes that in a way that should not impact FHS system users.

That way users can specify their needed `PATH` in the config along with `TERMCMD`