### PR TITLE
feat: put systemd service under session.slice

### DIFF
--- a/contrib/systemd/xdg-desktop-portal-termfilechooser.service.in
+++ b/contrib/systemd/xdg-desktop-portal-termfilechooser.service.in
@@ -8,3 +8,4 @@ Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.termfilechooser
 ExecStart=@libexecdir@/xdg-desktop-portal-termfilechooser
 Restart=on-failure
+Slice=session.slice


### PR DESCRIPTION
systemd.special man page recommends putting portals in this slice

https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#session.slice

Hyprland xdg portal also has this: https://github.com/hyprwm/xdg-desktop-portal-hyprland/blob/8844ac1336460ba37f137325052116550f30b926/contrib/systemd/xdg-desktop-portal-hyprland.service.in#L12