### PR TITLE
add config item: show_instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The configuration is as follows:
 `[filechooser]`
 
 - `cmd`: The wrapper script/command to run.
+- `create_help_file`: Create destination save file with instructions. Must be *0* or *1* (default). See `man 5 xdg-desktop-portal-termfilechooser` for more info.
 - `default_dir`: The default directory to open if the application (e.g. firefox) does not suggest a path.
 - `env`: Sets the specified environment variables with the specified values.
     - `TERMCMD`: The environment variable that sets what command to use for launching a terminal.

--- a/contrib/config
+++ b/contrib/config
@@ -1,6 +1,8 @@
 [filechooser]
 cmd=yazi-wrapper.sh
 default_dir=$HOME
+; Uncomment to skip creating destination save files with instructions in them
+; create_help_file=0
 ; Uncomment and edit the line below to change the terminal emulator command
 ; env=TERMCMD=foot
 

--- a/include/config.h
+++ b/include/config.h
@@ -24,6 +24,7 @@ struct modes {
 struct config_filechooser {
     char *cmd;
     char *default_dir;
+    char create_help_file;
     struct modes *modes;
     struct environment *env;
 };

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -77,6 +77,30 @@ static void parse_string(char **dest, const char *value)
     *dest = shell_expand(value);
 }
 
+static void parse_bool(char *dest, const char *strval)
+{
+    if (strval == NULL || *strval == '\0') {
+        logprint(DEBUG, "config: skipping empty value in config file");
+        return;
+    }
+
+    char *value = strdup(strval);
+
+    char *ptr = value;
+    while (*ptr) {
+        *ptr = tolower(*ptr);
+        ptr++;
+    }
+
+    if (strcmp(value, "0") == 0) {
+        *dest = 0;
+    } else if (strcmp(value, "1") == 0) {
+        *dest = 1;
+    } else {
+        logprint(DEBUG, "config: unknown bool in config file");
+    }
+}
+
 static void parse_modes(enum Mode *mode, const char *modestr)
 {
     if (modestr == NULL || *modestr == '\0') {
@@ -142,6 +166,8 @@ static int handle_ini_filechooser(struct config_filechooser *filechooser_conf,
         parse_string(&filechooser_conf->cmd, value);
     } else if (strcmp(key, "default_dir") == 0) {
         parse_string(&filechooser_conf->default_dir, value);
+    } else if (strcmp(key, "create_help_file") == 0) {
+        parse_bool(&filechooser_conf->create_help_file, value);
     } else if (strcmp(key, "open_mode") == 0) {
         parse_modes(&filechooser_conf->modes->open_mode, value);
     } else if (strcmp(key, "save_mode") == 0) {
@@ -195,6 +221,8 @@ static void set_default_config(struct config_filechooser *config)
     default_modes->open_mode = MODE_SUGGESTED_DIR;
     default_modes->save_mode = MODE_SUGGESTED_DIR;
     config->modes = default_modes;
+
+    config->create_help_file = 1;
 
     struct environment *env = malloc(sizeof(struct environment));
     env->num_vars = 0;

--- a/xdg-desktop-portal-termfilechooser.5.scd
+++ b/xdg-desktop-portal-termfilechooser.5.scd
@@ -91,6 +91,13 @@ These options need to be placed under the *[filechooser]* section.
 
 	The default value is yazi-wrapper.sh
 
+*create_help_file* = _bool_
+	Populates the destination save file with instructions.
+
+	Accepted values are *0* and *1*.
+
+	The default value is *1*.
+
 *default_dir* = _directory_
 	Default directory to open in your file manager if the invoking program does not
 	provide one.
@@ -130,6 +137,7 @@ _last_ - Uses the parent directory of the last selected file. If the last
 ```
 [filechooser]
 cmd=yazi-wrapper.sh
+create_help_file=0
 default_dir=$HOME
 env=TERMCMD=foot
 	EDITOR=nvim


### PR DESCRIPTION
Add ability to disable writing instructions into destination save file.

This causes a overwrite prompt that is annoying. The "workaround" of always overwriting makes it easy to misclick or press an extra arrow key and accidentally overwrite files.

tested with this `config` and `qarma(qt zenity replacement)` below

save 'new' file - overwrite - different filename entirely

with and without new config option

```
[filechooser]
cmd=zenity.sh
show_instructions=0
default_dir=/tmp
open_mode=default
save_mode=default
```

```
#!/usr/bin/env sh
# This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
#
# For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`

set -ex

multiple="$1"
directory="$2"
save="$3"
path="$4"
out="$5"

cmd="zenity "
# /. ending will truncate to directory with NO filename (e.g. /tmp/ opens with filename tmp in /tmp)

if [ "$save" = "1" ]; then
    set -- --file-selection --save --filename="${path}"
elif [ "$directory" = "1" ]; then
    set -- --file-selection --directory --filename="${path}"
elif [ "$multiple" = "1" ]; then
    set -- --file-selection --multiple --filename="${path}/."
else # upload only 1 file
    set -- --file-selection --filename="${path}/."
fi

for arg in "$@"; do
    # escape double quotes
    escaped=$(printf "%s" "$arg" | sed 's/"/\\"/g')
    # escape spaces
    cmd="$cmd \"$escaped\""
done

# remove on exit becuase this script makes it
if ! sh -c "$cmd" > "$out" ; then
  sh -c "eval 'sleep 2s ; rm $out'" &
fi
```
