### PR TITLE
Remove more characters in yazi wrapper

### DIFF
--- a/contrib/yazi-wrapper.sh
+++ b/contrib/yazi-wrapper.sh
@@ -34,8 +34,8 @@ fi
 
 command="$termcmd $cmd"
 for arg in "$@"; do
-    # escape double quotes
-    escaped=$(printf "%s" "$arg" | sed 's/"/\\"/g')
+    # remove problematic characters
+    escaped=$(printf "%s" "$arg" | sed -E 's/[\"\(\)\{\}\|]//g')
     # escape spaces
     command="$command \"$escaped\""
 done


### PR DESCRIPTION
When I tied to download a pdf with brackets in its name from 

```
https://example.tld/lecture 1 (Introduction).pdf
```

... the script failed. I figured it is because of the brackets in the file name. The PR version of the script works for me, but feel free to change anything.