### PR TITLE
Add Kitty file chooser wrapper script

### DIFF
--- a/contrib/kitty-wrapper.sh
+++ b/contrib/kitty-wrapper.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/bash
+# This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
+#
+# For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
+
+multiple="$1"
+directory="$2"
+save="$3"
+path="$4"
+out="$5"
+debug="$6"
+
+set -e
+
+if [ "$debug" = 1 ]; then
+    set -x
+fi
+
+case "$multiple$directory$save" in
+    000) mode=file ;;
+    100) mode=files ;;
+    010) mode=dir ;;
+    001) mode=save-file ;;
+    110) mode=dirs ;;
+    101) mode=save-files ;;
+    011) mode=save-dir ;;
+    111) mode=save-dir ;;
+    *) echo "invalid params" >&2; exit 1
+esac
+
+touch $out
+
+if [ "$save" = 1 ]; then
+    kitty --class filechooser kitty +kitten choose-files --mode=$mode --write-output-to "$out" --suggested-save-file-path "$path"
+else
+    kitty --class filechooser kitty +kitten choose-files --mode=$mode --write-output-to "$out"
+fi

--- a/contrib/kitty-wrapper.sh
+++ b/contrib/kitty-wrapper.sh
@@ -33,7 +33,7 @@ touch $out
 if [ "$save" = 1 ]; then
     escaped=$(printf "%s" "$path" | sed 's/"/\\"/g')
     kitty --class filechooser kitty +kitten choose-files --mode=$mode \
-        --write-output-to "$out" --suggested-save-file-path "$escaped"
+        --write-output-to "$out" --suggested-save-file-name "$escaped"
 else
     kitty --class filechooser kitty +kitten choose-files --mode=$mode \
         --write-output-to "$out"

--- a/contrib/kitty-wrapper.sh
+++ b/contrib/kitty-wrapper.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env sh
 # This wrapper script is invoked by xdg-desktop-portal-termfilechooser.
 #
 # For more information about input/output arguments read `xdg-desktop-portal-termfilechooser(5)`
@@ -31,7 +31,10 @@ esac
 touch $out
 
 if [ "$save" = 1 ]; then
-    kitty --class filechooser kitty +kitten choose-files --mode=$mode --write-output-to "$out" --suggested-save-file-path "$path"
+    escaped=$(printf "%s" "$path" | sed 's/"/\\"/g')
+    kitty --class filechooser kitty +kitten choose-files --mode=$mode \
+        --write-output-to "$out" --suggested-save-file-path "$escaped"
 else
-    kitty --class filechooser kitty +kitten choose-files --mode=$mode --write-output-to "$out"
+    kitty --class filechooser kitty +kitten choose-files --mode=$mode \
+        --write-output-to "$out"
 fi

--- a/contrib/kitty-wrapper.sh
+++ b/contrib/kitty-wrapper.sh
@@ -33,7 +33,7 @@ touch $out
 if [ "$save" = 1 ]; then
     escaped=$(printf "%s" "$path" | sed 's/"/\\"/g')
     kitty --class filechooser kitty +kitten choose-files --mode=$mode \
-        --write-output-to "$out" --suggested-save-file-name "$escaped"
+        --write-output-to "$out" --suggested-save-file-name "\"$escaped\""
 else
     kitty --class filechooser kitty +kitten choose-files --mode=$mode \
         --write-output-to "$out"


### PR DESCRIPTION
Adds a wrapper script for the new Kitty [file chooser](https://sw.kovidgoyal.net/kitty/kittens/choose-files/), intended for systems where the required panels support isn't present (e.g. i3). This script is not necessary for most Wayland systems. In those cases, the [recommended approach](https://sw.kovidgoyal.net/kitty/kittens/desktop-ui/) should be used instead.

There is an unexpected behaviour on my system where the file-saving dialogue doesn't autofill the recommended path.  The issue is independent of this script however.

In the case of i3, I also recommend using something like this line in the config
```
for_window [class="filechooser"] floating enable, resize set 1280 700, move position center
```
in order to launch the file chooser as a floating, centred window.